### PR TITLE
Update README.md mentioning GBIF Alert

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # early-alert-webapp
 The source code of the LIFE RIPARIAS early alert web application
 
-This website is powered by [Pterois](https://github.com/riparias/pterois), therefore this repository contains
+This website is powered by [GBIF Alert](https://github.com/riparias/gbif-alert), therefore this repository contains
 mostly configuration files, specific scripts and documentation for the LIFE RIPARIAS project.
 
 * [Production website](https://alert.riparias.be)


### PR DESCRIPTION
Replacing pterois with the final chosen name, GBIF Alert (`gbif-alert`). 